### PR TITLE
Pgo win weighted merge

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -79,7 +79,8 @@ function Build-WithPgo {
         [string]$Arch = '',
         [Parameter(Mandatory = $true)]
         [string]$OutputName,
-        [int]$Duration = 15
+        [int]$Duration = 15,
+        [hashtable]$Weights = @{}
     )
 
     # Step 1: Build instrumented binary
@@ -95,7 +96,7 @@ function Build-WithPgo {
     Copy-NodeExecutable -DestinationFileName $genName
 
     # Step 2: Collect profiles + merge
-    .\pgo.ps1 -PgoGenNode .\Release\node.exe -PhaseOnly -Duration $Duration
+    .\pgo.ps1 -PgoGenNode .\Release\node.exe -PhaseOnly -Duration $Duration -Weights $Weights
     $profdataName = $OutputName -replace '\.exe$', '.profdata'
     $destinationDir = Split-Path -Path $PSScriptRoot -Parent
     Copy-Item -Path (Join-Path $PSScriptRoot 'node.profdata') -Destination (Join-Path $destinationDir $profdataName) -Force
@@ -128,6 +129,7 @@ Build-WithLto -Lto lto -OutputName "node_lto.exe"
 Build-WithLto -Lto ltcg -Arch arm64 -OutputName "node_branch_ltcg_arm64.exe"
 Build-WithLto -Lto thin-lto -Arch arm64 -OutputName "node_thin_lto_arm64.exe"
 Build-WithLto -Lto lto -Arch arm64 -OutputName "node_lto_arm64.exe"
+
 # PGO builds
 Build-WithPgo -OutputName "node_pgo.exe"
 Build-WithPgo -Lto ltcg -OutputName "node_ltcg_pgo.exe"
@@ -136,3 +138,25 @@ Build-WithPgo -Lto lto -OutputName "node_lto_pgo.exe"
 Build-WithPgo -Lto ltcg -Arch arm64 -OutputName "node_ltcg_pgo_arm64.exe"
 Build-WithPgo -Lto thin-lto -Arch arm64 -OutputName "node_thin_lto_pgo_arm64.exe"
 Build-WithPgo -Lto lto -Arch arm64 -OutputName "node_lto_pgo_arm64.exe"
+
+# PGO builds with weights
+$pgoWeights = @{
+    'http-server'     = 30
+    'json'            = 20
+    'crypto'          = 12
+    'streams-buffers' = 10
+    'fs'              = 6
+    'async-patterns'  = 5
+    'url-string'      = 8
+    'compression'     = 5
+    'net'             = 3
+    'module-loading'  = 1
+    'child-workers'   = 1
+}
+Build-WithPgo -OutputName "node_pgo_weights.exe" -Weights $pgoWeights
+Build-WithPgo -Lto ltcg -OutputName "node_ltcg_pgo_weights.exe" -Weights $pgoWeights
+Build-WithPgo -Lto thin-lto -OutputName "node_thin_lto_pgo_weights.exe" -Weights $pgoWeights
+Build-WithPgo -Lto lto -OutputName "node_lto_pgo.exe" -Weights $pgoWeights
+Build-WithPgo -Lto ltcg -Arch arm64 -OutputName "node_ltcg_pgo_arm64.exe" -Weights $pgoWeights
+Build-WithPgo -Lto thin-lto -Arch arm64 -OutputName "node_thin_lto_pgo_arm64.exe" -Weights $pgoWeights
+Build-WithPgo -Lto lto -Arch arm64 -OutputName "node_lto_pgo_arm64.exe" -Weights $pgoWeights

--- a/pgo.ps1
+++ b/pgo.ps1
@@ -262,7 +262,8 @@ if ($skipProfileCollection) {
         Write-Host "Found $($profrawFiles.Count) .profraw file(s) to merge."
     }
 
-    # Build the merge command. llvm-profdata accepts a list of inputs or a wildcard via response file.
+    # Building the merge command, groupping profraw files by pgo JS script names.
+    # llvm-profdata accepts a list of inputs or a wildcard via response file.
     $groups = @{}
 
     foreach ($file in $profrawFiles) {
@@ -285,6 +286,7 @@ if ($skipProfileCollection) {
         Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, $w)     
     }
 
+    # llvm-profdata supports only integer values for weights
     $maxCount = ($groups.Values | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
 
     $mergeArgs = [System.Collections.Generic.List[string]]@("merge", "--output=$profdata")

--- a/pgo.ps1
+++ b/pgo.ps1
@@ -19,7 +19,8 @@ param(
     [ValidateSet('', 'ltcg', 'thin-lto', 'lto')]
     [string]$Lto = '',
     [switch]$PhaseOnly,
-    [int]$Duration = 15
+    [int]$Duration = 15,
+    [hashtable]$Weights = @{}
 )
 
 Set-StrictMode -Version Latest
@@ -262,7 +263,6 @@ if ($skipProfileCollection) {
     }
 
     # Build the merge command. llvm-profdata accepts a list of inputs or a wildcard via response file.
-    $scriptWeights = [ordered]@{}
     $groups = @{}
 
     foreach ($file in $profrawFiles) {
@@ -281,7 +281,8 @@ if ($skipProfileCollection) {
     Write-Host "Profile groups (weighted merge):"
 
     foreach ($key in ($groups.Keys | Sort-Object)) {
-        Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, 1)     
+        $w = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
+        Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, $w)     
     }
 
     $maxCount = ($groups.Values | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
@@ -289,8 +290,8 @@ if ($skipProfileCollection) {
     $mergeArgs = [System.Collections.Generic.List[string]]@("merge", "--output=$profdata")
 
     foreach ($key in $groups.Keys) {
-        $groupWeight = if ($scriptWeights.Contains($key)) { $maxCount } else { $maxCount }
-        $perFileWeight = $groupWeight / $groups[$key].Count
+        $groupWeight = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
+        $perFileWeight = $groupWeight * $maxCount / $groups[$key].Count
         foreach ($file in $groups[$key]) {
             $mergeArgs.Add("--weighted-input=$perFileWeight,$file")
         }

--- a/pgo.ps1
+++ b/pgo.ps1
@@ -295,9 +295,6 @@ Write-Host "`n=== STEP 4: Build optimised binary (pgo-use) ===" -ForegroundColor
 
 # vcbuild / common.gypi expect node.profdata in the workspace root (same dir as node.gyp)
 # – it's already there from the merge step above.
-
-git clean -fdx *> $null
-
 # Preserve node.profdata across git clean by staging it
 git add node.profdata
 

--- a/pgo.ps1
+++ b/pgo.ps1
@@ -262,43 +262,46 @@ if ($skipProfileCollection) {
         Write-Host "Found $($profrawFiles.Count) .profraw file(s) to merge."
     }
 
-    # Building the merge command, groupping profraw files by pgo JS script names.
+    # Building the merge command, groupping profraw files by pgo JS script names if weights are provided.
     # llvm-profdata accepts a list of inputs or a wildcard via response file.
-    $groups = @{}
+    if ($Weights.Count -eq 0) {
+        $mergeArgs = @("merge", "--output=$profdata") + ($profrawFiles | Select-Object -ExpandProperty FullName)
+    } else {
+        $groups = @{}
 
-    foreach ($file in $profrawFiles) {
-        $parts = $file.BaseName -split '-'
-        $key = if ($parts.Count -ge 4) {
-            $parts[1..($parts.Count - 3)] -join '-'
-        } else {
-            '__orchestrator__'
+        foreach ($file in $profrawFiles) {
+            $parts = $file.BaseName -split '-'
+            $key = if ($parts.Count -ge 4) {
+                $parts[1..($parts.Count - 3)] -join '-'
+            } else {
+                '__orchestrator__'
+            }
+            if (-not $groups.ContainsKey($key)) {
+                $groups[$key] = [System.Collections.Generic.List[string]]::new()
+            }
+            $groups[$key].Add($file.FullName)
         }
-        if (-not $groups.ContainsKey($key)) {
-            $groups[$key] = [System.Collections.Generic.List[string]]::new()
+
+        Write-Host "Profile groups (weighted merge):"
+
+        foreach ($key in ($groups.Keys | Sort-Object)) {
+            $w = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
+            Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, $w)     
         }
-        $groups[$key].Add($file.FullName)
-    }
 
-    Write-Host "Profile groups (weighted merge):"
+        # llvm-profdata supports only integer values for weights
+        $maxCount = ($groups.Values | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
 
-    foreach ($key in ($groups.Keys | Sort-Object)) {
-        $w = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
-        Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, $w)     
-    }
+        $mergeArgs = [System.Collections.Generic.List[string]]@("merge", "--output=$profdata")
 
-    # llvm-profdata supports only integer values for weights
-    $maxCount = ($groups.Values | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
-
-    $mergeArgs = [System.Collections.Generic.List[string]]@("merge", "--output=$profdata")
-
-    foreach ($key in $groups.Keys) {
-        $groupWeight = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
-        $perFileWeight = $groupWeight * $maxCount / $groups[$key].Count
-        foreach ($file in $groups[$key]) {
-            $mergeArgs.Add("--weighted-input=$perFileWeight,$file")
+        foreach ($key in $groups.Keys) {
+            $groupWeight = if ($Weights.ContainsKey($key)) { $Weights[$key] } else { 1 }
+            $perFileWeight = $groupWeight * $maxCount / $groups[$key].Count
+            foreach ($file in $groups[$key]) {
+                $mergeArgs.Add("--weighted-input=$perFileWeight,$file")
+            }
         }
     }
-
     Write-Host "Merging: $llvmProfdata $($mergeArgs -join ' ')"
 
     $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()

--- a/pgo.ps1
+++ b/pgo.ps1
@@ -262,7 +262,40 @@ if ($skipProfileCollection) {
     }
 
     # Build the merge command. llvm-profdata accepts a list of inputs or a wildcard via response file.
-    $mergeArgs = @("merge", "--output=$profdata") + ($profrawFiles | Select-Object -ExpandProperty FullName)
+    $scriptWeights = [ordered]@{}
+    $groups = @{}
+
+    foreach ($file in $profrawFiles) {
+        $parts = $file.BaseName -split '-'
+        $key = if ($parts.Count -ge 4) {
+            $parts[1..($parts.Count - 3)] -join '-'
+        } else {
+            '__orchestrator__'
+        }
+        if (-not $groups.ContainsKey($key)) {
+            $groups[$key] = [System.Collections.Generic.List[string]]::new()
+        }
+        $groups[$key].Add($file.FullName)
+    }
+
+    Write-Host "Profile groups (weighted merge):"
+
+    foreach ($key in ($groups.Keys | Sort-Object)) {
+        Write-Host ("  {0,-22} {1,4} file(s)   group weight {2}" -f $key, $groups[$key].Count, 1)     
+    }
+
+    $maxCount = ($groups.Values | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
+
+    $mergeArgs = [System.Collections.Generic.List[string]]@("merge", "--output=$profdata")
+
+    foreach ($key in $groups.Keys) {
+        $groupWeight = if ($scriptWeights.Contains($key)) { $maxCount } else { $maxCount }
+        $perFileWeight = $groupWeight / $groups[$key].Count
+        foreach ($file in $groups[$key]) {
+            $mergeArgs.Add("--weighted-input=$perFileWeight,$file")
+        }
+    }
+
     Write-Host "Merging: $llvmProfdata $($mergeArgs -join ' ')"
 
     $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()

--- a/tools/pgo/pgo-run-all.js
+++ b/tools/pgo/pgo-run-all.js
@@ -138,12 +138,17 @@ Example:
   return args;
 }
 
-function runScript(scriptPath, duration, verbose) {
+function runScript(scriptPath, duration, verbose, scriptName) {
   return new Promise((resolve, reject) => {
     const env = {
       ...process.env,
       PGO_TRAINING_DURATION: String(duration * 1000),
     };
+    const profileFile = process.env.LLVM_PROFILE_FILE
+    if (profileFile) {
+      const dir = path.dirname(profileFile)
+      env.LLVM_PROFILE_FILE = path.join(dir, `node-${scriptName}-%p-%m.profraw`)
+    }
     const child = fork(scriptPath, [], {
       stdio: verbose ? 'inherit' : ['ignore', 'pipe', 'pipe', 'ipc'],
       env,
@@ -243,7 +248,7 @@ async function main() {
     console.log(`    ${script.desc}`);
 
     const scriptStart = Date.now();
-    const result = await runScript(scriptPath, args.duration, args.verbose);
+    const result = await runScript(scriptPath, args.duration, args.verbose, script.name);
     const elapsed = ((Date.now() - scriptStart) / 1000).toFixed(1);
 
     const status = result.code === 0 ? 'OK' : `FAIL(${result.code})`;


### PR DESCRIPTION
# Changes
Added an option to merge profraw files with weights in the `pgo.ps1` script. An example of its use is provided in the `build.ps1` script.

## Grouping profraw files
It was noticed that some of the JS PGO scripts generate more than one profraw file, specifically, the `child-workers` script generates around 120 files. Now, when merging with weights, all profraw files generated by the `child-workers` script are grouped together, and the group as a whole carries equal weight to each of the other scripts.

## Tests
The tests were ran with the weights provided in `build.ps1` file.

```
=== Node.js Binary Benchmark: node_main vs node_branch_ltcg vs node_ltcg_pgo_use vs node_pgo_use vs node_thin_lto_pgo_use vs node_thin_lto vs node_ltcg_pgo_weights_use vs node_pgo_weights_use vs node_thin_lto_pgo_weights_use ===

Platform : win32 x64
CPUs     : AMD Ryzen 9 8945HX with Radeon Graphics         (32 cores)
RAM      : 32048.53 MB
Date     : 2026-05-13T13:31:45.738Z
Binaries : 9
Iterations per benchmark: 30 (warmup: 10)

node_main : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_main.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_branch_ltcg : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_branch_ltcg.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_ltcg_pgo_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_ltcg_pgo_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_pgo_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_pgo_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_thin_lto_pgo_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_thin_lto_pgo_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_thin_lto : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_thin_lto.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_ltcg_pgo_weights_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_ltcg_pgo_weights_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_pgo_weights_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_pgo_weights_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18
node_thin_lto_pgo_weights_use : C:\Users\kirill\dev\node-msvc-clangcl-perf\presets\windows-pgo-kirill-weights\node_thin_lto_pgo_weights_use.exe
  Node: v26.0.0-pre, V8: 14.3.127.18-node.18

Running: Binary Size... done
Running: Startup Time... done
Running: require("fs")... done
Running: Require 10 modules... done
Running: Memory at Startup... done
Running: Buffer Operations... done
Running: JSON parse/stringify... done
Running: URL parsing (Ada)... done
Running: Zlib compress/decomp... done
Running: TextEncoder/Decoder... done
Running: Stream pipe throughput... done
Running: FS readFileSync... done
Running: Memory under load... done


-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| Benchmark                                 | node_main                         | node_branch_ltcg                  | node_ltcg_pgo_use                 | node_pgo_use                      | node_thin_lto_pgo_use             | node_thin_lto                     | node_ltcg_pgo_weights_use         | node_pgo_weights_use              | node_thin_lto_pgo_weights_use     | Winner                         |
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| Binary Size                               | 106.21 MB (+19.11%)               | 92.72 MB (+3.97%)                 | 89.56 MB (+0.43%)                 | 89.50 MB (+0.37%)                 | 91.21 MB (+2.29%)                 | 95.92 MB (+7.57%)                 | 89.23 MB (+0.06%)                 | 89.17 MB                          | 90.26 MB (+1.22%)                 | node_pgo_weights_use           |
| Startup Time (node -e "0")                | 35.90 ms ±2.30 ms (+0.89%)        | 38.38 ms ±1.87 ms (+7.85%)        | 35.58 ms ±1.88 ms                 | 36.04 ms ±1.81 ms (+1.29%)        | 35.62 ms ±1.16 ms (+0.10%)        | 37.73 ms ±1.51 ms (+6.03%)        | 36.21 ms ±1.33 ms (+1.76%)        | 35.73 ms ±2.65 ms (+0.42%)        | 36.61 ms ±1.63 ms (+2.90%)        | node_ltcg_pgo_use              |
| require("fs") + exit                      | 35.64 ms ±1.39 ms (+0.95%)        | 37.87 ms ±1.77 ms (+7.28%)        | 35.30 ms ±0.92 ms                 | 35.64 ms ±16.98 ms (+0.97%)       | 35.56 ms ±1.34 ms (+0.73%)        | 37.18 ms ±1.16 ms (+5.32%)        | 35.86 ms ±1.12 ms (+1.58%)        | 36.13 ms ±1.44 ms (+2.34%)        | 36.07 ms ±1.15 ms (+2.18%)        | node_ltcg_pgo_use              |
| Require 10 core modules                   | 45.16 ms ±2.00 ms (+3.88%)        | 47.81 ms ±1.06 ms (+9.98%)        | 44.79 ms ±1.71 ms (+3.03%)        | 44.57 ms ±1.62 ms (+2.51%)        | 43.48 ms ±1.03 ms                 | 46.63 ms ±1.25 ms (+7.25%)        | 44.64 ms ±1.20 ms (+2.69%)        | 44.65 ms ±1.78 ms (+2.70%)        | 44.21 ms ±1.40 ms (+1.69%)        | node_thin_lto_pgo_use          |
| Memory: RSS at startup                    | 39.93 MB ±40.67 KB (+31.16%)      | 32.71 MB ±32.55 KB (+7.44%)       | 30.44 MB ±47.80 KB                | 30.47 MB ±51.29 KB (+0.10%)       | 30.88 MB ±39.99 KB (+1.43%)       | 32.37 MB ±45.04 KB (+6.33%)       | 30.59 MB ±48.05 KB (+0.49%)       | 30.68 MB ±48.84 KB (+0.78%)       | 30.83 MB ±33.29 KB (+1.27%)       | node_ltcg_pgo_use              |
| Memory: Heap Used at startup              | 3.71 MB ±0 B                      | 3.71 MB ±0 B (+0.00%)             | 3.71 MB ±0 B (+0.01%)             | 3.71 MB ±0 B (+0.01%)             | 3.71 MB ±0 B (+0.01%)             | 3.71 MB ±0 B (+0.00%)             | 3.71 MB ±0 B (+0.01%)             | 3.71 MB ±0 B (+0.01%)             | 3.71 MB ±0 B (+0.01%)             | ~Tie                           |
| Memory: Heap Total at startup             | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | 4.88 MB ±0 B                      | Tie                            |
| Memory: External at startup               | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B                      | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | 1.38 MB ±0 B (+0.00%)             | ~Tie                           |
| Buffer ops (50k alloc+fill+hex)           | 49.23 ms ±2.89 ms (+20.51%)       | 49.55 ms ±3.10 ms (+21.31%)       | 45.84 ms ±3.38 ms (+12.23%)       | 46.38 ms ±3.68 ms (+13.55%)       | 41.95 ms ±3.54 ms (+2.69%)        | 47.79 ms ±3.06 ms (+17.01%)       | 44.91 ms ±3.31 ms (+9.95%)        | 46.56 ms ±3.13 ms (+13.99%)       | 40.85 ms ±3.74 ms                 | node_thin_lto_pgo_weights_use  |
| JSON parse+stringify (20k iters)          | 1614.85 ms ±28.32 ms (+43.92%)    | 1613.71 ms ±21.12 ms (+43.82%)    | 1294.63 ms ±20.14 ms (+15.38%)    | 1290.16 ms ±98.96 ms (+14.98%)    | 1122.26 ms ±50.48 ms (+0.02%)     | 1459.61 ms ±17.25 ms (+30.09%)    | 1293.56 ms ±17.90 ms (+15.29%)    | 1292.77 ms ±13.32 ms (+15.22%)    | 1122.03 ms ±15.82 ms              | node_thin_lto_pgo_weights_use  |
| URL parsing (50k, Ada C++)                | 14.17 ms ±0.23 ms (+40.60%)       | 14.44 ms ±0.20 ms (+43.37%)       | 12.18 ms ±0.30 ms (+20.94%)       | 12.32 ms ±0.46 ms (+22.29%)       | 10.08 ms ±0.21 ms                 | 13.01 ms ±0.23 ms (+29.17%)       | 11.68 ms ±0.21 ms (+15.91%)       | 11.84 ms ±0.31 ms (+17.55%)       | 10.31 ms ±0.24 ms (+2.28%)        | node_thin_lto_pgo_use          |
| Zlib deflate+inflate 64KB (500x)          | 91.79 ms ±1.18 ms (+1.76%)        | 91.48 ms ±1.34 ms (+1.41%)        | 90.21 ms ±1.74 ms                 | 91.00 ms ±1.42 ms (+0.88%)        | 90.52 ms ±1.09 ms (+0.34%)        | 90.44 ms ±1.06 ms (+0.26%)        | 90.95 ms ±1.52 ms (+0.83%)        | 91.58 ms ±1.25 ms (+1.52%)        | 90.42 ms ±1.43 ms (+0.24%)        | ~Tie                           |
| TextEncoder/Decoder (10k iters)           | 98.14 ms ±1.65 ms (+3.20%)        | 98.46 ms ±2.08 ms (+3.54%)        | 96.60 ms ±1.26 ms (+1.59%)        | 97.50 ms ±1.47 ms (+2.52%)        | 95.10 ms ±1.21 ms                 | 97.12 ms ±1.30 ms (+2.13%)        | 97.47 ms ±1.42 ms (+2.50%)        | 98.18 ms ±1.27 ms (+3.24%)        | 95.66 ms ±1.54 ms (+0.60%)        | node_thin_lto_pgo_use          |
| Stream pipe 3-chain (200x100 16KB)        | 17.70 ms ±0.33 ms (+13.19%)       | 17.82 ms ±0.44 ms (+13.96%)       | 16.58 ms ±0.67 ms (+6.02%)        | 16.55 ms ±0.41 ms (+5.82%)        | 15.64 ms ±0.32 ms                 | 17.38 ms ±0.45 ms (+11.17%)       | 16.66 ms ±0.39 ms (+6.51%)        | 16.63 ms ±0.38 ms (+6.38%)        | 15.90 ms ±0.57 ms (+1.65%)        | node_thin_lto_pgo_use          |
| FS: readFileSync 64KB (5000x)             | 223.67 ms ±3.93 ms (+6.44%)       | 223.25 ms ±4.31 ms (+6.23%)       | 215.32 ms ±3.59 ms (+2.46%)       | 216.01 ms ±4.16 ms (+2.79%)       | 210.95 ms ±3.11 ms (+0.38%)       | 218.40 ms ±3.06 ms (+3.93%)       | 216.11 ms ±4.50 ms (+2.84%)       | 219.13 ms ±3.93 ms (+4.27%)       | 210.14 ms ±5.16 ms                | node_thin_lto_pgo_weights_use  |
| Memory: RSS under 500k objects            | 162.70 MB ±226.84 KB (+5.13%)     | 158.24 MB ±191.57 KB (+2.25%)     | 154.76 MB ±203.67 KB              | 154.85 MB ±164.79 KB (+0.06%)     | 155.43 MB ±203.89 KB (+0.43%)     | 157.82 MB ±169.42 KB (+1.98%)     | 154.79 MB ±185.76 KB (+0.02%)     | 154.86 MB ±212.20 KB (+0.06%)     | 155.09 MB ±158.32 KB (+0.21%)     | node_ltcg_pgo_use              |
| Memory: Heap Used under 500k objects      | 84.89 MB ±25.28 KB (+0.01%)       | 84.88 MB ±22.23 KB (+0.01%)       | 84.87 MB ±22.79 KB                | 84.89 MB ±21.37 KB (+0.01%)       | 84.88 MB ±21.90 KB (+0.00%)       | 84.88 MB ±21.95 KB (+0.00%)       | 84.88 MB ±18.52 KB (+0.01%)       | 84.88 MB ±21.22 KB (+0.00%)       | 84.88 MB ±24.14 KB (+0.00%)       | ~Tie                           |
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Win count (17 benchmarks, 5 statistical ties):
  node_main             :   0 wins,     0.00% weighted advantage (0.0% share)
  node_branch_ltcg      :   0 wins,     0.00% weighted advantage (0.0% share)
  node_ltcg_pgo_use     :   4 wins,   101.73% weighted advantage (13.3% share)
  node_pgo_use          :   0 wins,     0.00% weighted advantage (0.0% share)
  node_thin_lto_pgo_use :   4 wins,   309.84% weighted advantage (40.5% share)
  node_thin_lto         :   0 wins,     0.00% weighted advantage (0.0% share)
  node_ltcg_pgo_weights_use:   0 wins,     0.00% weighted advantage (0.0% share)
  node_pgo_weights_use  :   1 wins,    35.02% weighted advantage (4.6% share)
  node_thin_lto_pgo_weights_use:   3 wins,   319.32% weighted advantage (41.7% share)

Overall winner by weighted advantage: node_thin_lto_pgo_weights_use
```